### PR TITLE
[RTW-19] Install pybind11 to either the devel- or the install-space directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,35 +13,14 @@ if(NOT pybind11_FOUND)
   ExternalProject_Add(pybind11_src
     URL "https://github.com/pybind/pybind11/archive/v2.10.3.zip"
     UPDATE_COMMAND ""
-    CMAKE_ARGS -DPYBIND11_NOPYTHON=TRUE
-              -DPYBIND11_TEST=OFF
-              -DPYBIND11_INSTALL=ON
-              -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/install
-    # Workaround if DESTDIR is set
-    # See https://gitlab.kitware.com/cmake/cmake/-/issues/18165.
-    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR= install
-  )
-
-  # Copy cmake/pybind11 and include/pybind11 to corresponding devel space folders
-  ExternalProject_Add_Step(pybind11_src CopyToDevel
-    COMMENT "Copying to devel"
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/share/cmake/pybind11 ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/install/include/pybind11 ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/pybind11
-    DEPENDEES install
+    CMAKE_ARGS
+      -DPYBIND11_NOPYTHON=TRUE
+      -DPYBIND11_TEST=OFF
+      -DPYBIND11_INSTALL=ON
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
   )
 endif()
 
-file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
 catkin_package(
-  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
   CFG_EXTRAS pybind11_catkin.cmake
-)
-
-install(
-  DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-install(
-  DIRECTORY ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/cmake/pybind11_catkin.cmake.in
+++ b/cmake/pybind11_catkin.cmake.in
@@ -4,24 +4,7 @@ cmake_minimum_required(VERSION 3.4)
 # To be able to configure, we need to set CMP0069 (interprocedural optimization) to NEW
 # cmake_policy(SET CMP0069 NEW)
 
-find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ QUIET)
-
-if(NOT pybind11_FOUND)
-    # Configure pybind11 using the cmake file provided by the upstream package.
-    # This finds python includes and libs and defines pybind11_add_module()
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-    set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
-    include(pybind11Config)
-    include(pybind11Common)
-    include(pybind11Tools)
-endif()
-
-# set variables used by pybind11_add_module()
-if(@INSTALLSPACE@)
-  set(pybind11_catkin_INCLUDE_DIRS "${pybind11_catkin_INCLUDE_DIRS}/@PROJECT_NAME@")
-endif()
-set(PYBIND11_INCLUDE_DIR "${pybind11_catkin_INCLUDE_DIRS}")
-list(APPEND pybind11_catkin_INCLUDE_DIRS "${PYTHON_INCLUDE_DIRS}")
+find_package(pybind11 @PYBIND11_MINIMUM_REQUIRED_VERSION@ REQUIRED)
 
 macro(pybind_add_module target_name other)
     pybind11_add_module(${ARGV})

--- a/package.xml
+++ b/package.xml
@@ -18,4 +18,8 @@
   <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_export_depend>
   
   <depend condition="($ROS_DISTRO != melodic) and ($ROS_DISTRO != noetic)">pybind11-dev</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
... such that the package can be found directly via its own CMake configuration, bypassing `pybind11_catkin-config.cmake`.

Starting from Ubuntu Jammy 22.04 the system version provided by package `pybind11-dev` works fine. Downstream packages can find and use `pybind11` directly, phasing out the extra package `pybind11_catkin`. For that to work also in older Ubuntu versions, we still install `pybind11_catkin` but let the embedded `pybind11` install its headers and CMake configuration directly to `CMAKE_INSTALL_PREFIX` instead of internalizing it.

_Note:_ This approach only works for isolated builds that support the `<build_type>cmake</build_type>` tag in `package.xml`.